### PR TITLE
Add in deprecation warnings for Chef 12 removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Chef cookbook to install and configure stunnel
 
+## DEPRECATION WARNING
+
+This is the final release to support Chef 12 which is End of Life as of April 2018. If you still need Chef 12 support, please version pin a 3.x release to prevent possible issues. To migrate, please see the README with migration instructions.
+
 ## Requirements
 
 * Chef 12.6+

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             'stunnel'
+name             'stunnel' # ~FC121
 maintainer       'DNSimple Corp'
 maintainer_email 'ops@dnsimple.com'
 license          'Apache-2.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,11 @@
 # limitations under the License.
 #
 
+log 'deprecation warning' do
+  message 'This is the last release to support Chef 12. 4.0.0 will be Chef 13+ only so please version pin if you need to. Please see README with upgrade instructions in the new release.'
+  level :warn
+end
+
 if node['stunnel']['install_method'] == 'source'
   include_recipe 'stunnel::source'
 else

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -3,7 +3,7 @@ log 'deprecation warning' do
   level :warn
 end
 
-include_recipe 'build-essential'
+build_essential 'stunnel requirement'
 
 package node['stunnel']['ssl_devel']
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -28,4 +28,3 @@ end
 link '/usr/bin/stunnel' do
   to '/usr/local/bin/stunnel'
 end
-

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,3 +1,8 @@
+log 'deprecation warning' do
+  message 'This is the last release to support Chef 12. 4.0.0 will be Chef 13+ only so please version pin if you need to. Please see README with upgrade instructions in the new release.'
+  level :warn
+end
+
 include_recipe 'build-essential'
 
 package node['stunnel']['ssl_devel']
@@ -23,3 +28,4 @@ end
 link '/usr/bin/stunnel' do
   to '/usr/local/bin/stunnel'
 end
+


### PR DESCRIPTION
This sprays warnings everywhere to deprecate Chef 12 support since it is now End of Life as of April 2018. It is intended to be a patch release to give folks ample warning of the deprecations.